### PR TITLE
fix: remove user id from primary keys

### DIFF
--- a/tap_openai/streams.py
+++ b/tap_openai/streams.py
@@ -14,7 +14,7 @@ class BillingUsageStream(OpenAIStream):
 
     name = "billing_usage"
     path = "/v1/dashboard/billing/usage/export"
-    primary_keys: t.ClassVar[list[str]] = ["user_id", "name", "date"]
+    primary_keys: t.ClassVar[list[str]] = ["name", "date"]
     replication_key = None
     schema = th.PropertiesList(
         th.Property("currency", th.StringType),


### PR DESCRIPTION
Tap is failing because user id is not present in the response from openai, I don't think we can use `user_id` as a primary key because it's optional. 